### PR TITLE
Removed logging of errors that are raised anyway

### DIFF
--- a/pjsip/include/pjsua2/media.hpp
+++ b/pjsip/include/pjsua2/media.hpp
@@ -662,12 +662,7 @@ class AudioMediaCapture : public AudioMedia {
 public:
     AudioMediaCapture();
     ~AudioMediaCapture();
-    void createMediaCapture(
-        unsigned clock_rate,
-        unsigned channel_count,
-        unsigned samples_per_frame,
-        unsigned bits_per_sample
-    );
+    void createMediaCapture(AudioMedia &media);
     void getFrames(char **data, size_t *datasize);
     string getFramesAsString();
     // static pj_status_t processFrames(pjmedia_port *, void *);

--- a/pjsip/include/pjsua2/types.hpp
+++ b/pjsip/include/pjsua2/types.hpp
@@ -163,7 +163,6 @@ struct Error
 #   define PJSUA2_RAISE_ERROR3(status,op,txt)   \
         do { \
             Error err_ = Error(status, op, txt, __FILE__, __LINE__); \
-            PJ_LOG(1,(THIS_FILE, "%s", err_.info().c_str())); \
             throw err_; \
         } while (0)
 
@@ -180,7 +179,6 @@ struct Error
 #   define PJSUA2_RAISE_ERROR3(status,op,txt)   \
         do { \
             Error err_ = Error(status, op, txt, string(), 0); \
-            PJ_LOG(1,(THIS_FILE, "%s", err_.info().c_str())); \
             throw err_; \
         } while (0)
 

--- a/pjsip/src/pjsua2/media.cpp
+++ b/pjsip/src/pjsua2/media.cpp
@@ -480,22 +480,18 @@ AudioMediaCapture::~AudioMediaCapture()
     }
 }
 
-void AudioMediaCapture::createMediaCapture(
-    unsigned clock_rate,
-    unsigned channel_count,
-    unsigned samples_per_frame,
-    unsigned bits_per_sample
-)
+void AudioMediaCapture::createMediaCapture(AudioMedia &media)
 {
-    frame_size = bits_per_sample*samples_per_frame*channel_count/8;
+    ConfPortInfo port_info = media.getPortInfo();
+    frame_size = port_info.format.bits_per_sample*port_info.format.samples_per_frame*port_info.format.channel_count/8;
     frame_buffer = pj_pool_zalloc(pool, frame_size);
     pjmedia_mem_capture_create( pool, //Pool
                           frame_buffer, //Buffer
                           frame_size, //Buffer Size
-                          clock_rate,
-                          channel_count,
-                          samples_per_frame,
-                          bits_per_sample,
+                          port_info.format.clockRate,
+                          port_info.format.channelCount,
+                          port_info.format.samplesPerFrame,
+                          port_info.format.bitsPerSample,
                           0, //Options
                           &capture_port); //The return port}
     pjmedia_mem_capture_set_eof_cb2(capture_port, this, AudioMediaCapture::processFrames);


### PR DESCRIPTION
Removed 2 log statements that are being logged. They should not be logged, since the code raises them as an error anyway. We catch and handle those errors well, but still are treated to erroneous logging.